### PR TITLE
chore: fix package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "3.0.2",
   "description": "Fetch art for a movie or tv show: 'Oceans Eleven' ➔ http://path/to/oceans_eleven_poster.jpg",
   "license": "MIT",
-  "repository": "lacymorrow/movie-art",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lacymorrow/movie-art.git"
+  },
   "author": {
     "name": "Lacy Morrow",
     "email": "me@lacymorrow.com",


### PR DESCRIPTION
## Summary
- Normalize `repository` field in package.json per npm publish standards
- Convert string shorthand to object format with `type` and `url`
- Normalize URLs to `git+https://` format

Automated fix via `npm pkg fix`. Addresses npm publish warnings.